### PR TITLE
Fix: Align useForm resolver with FormInputs type definition

### DIFF
--- a/src/components/SearchComponent.tsx
+++ b/src/components/SearchComponent.tsx
@@ -9,6 +9,7 @@ export const SearchComponent = () => {
     <>
       <Search className="text-muted-foreground absolute left-2.5 top-2.5 h-5 w-5" />
       <Input
+        inputName="search"
         type="search"
         placeholder="Search beneficiary"
         className="bg-background w-full rounded-lg pl-8"

--- a/src/layout/NewTransactionComponent.tsx
+++ b/src/layout/NewTransactionComponent.tsx
@@ -15,11 +15,11 @@ const schema = yup.object().shape({
     .required('Account number is required')
     .matches(/^\d+$/, 'Account number must contain only digits'),
   address: yup.string().required('Address is required'),
-  description: yup.string(),
+  description: yup.string().required(),
   date: yup.date().required('Date is required'),
 });
 
-type FormInputs = Omit<Transaction, 'id' | 'date'> & { date: string };
+type FormInputs = Omit<Transaction, 'id'>;
 
 export const NewTransactionComponent = () => {
   const { addTransaction } = useGlobalContext();

--- a/src/layout/NewTransactionComponent.tsx
+++ b/src/layout/NewTransactionComponent.tsx
@@ -9,14 +9,21 @@ import { type Transaction } from '../types';
 
 const schema = yup.object().shape({
   beneficiary: yup.string().required('Beneficiary is required'),
-  amount: yup.number().positive('Amount must be positive').required('Amount is required'),
+  amount: yup
+    .number()
+    .positive('Amount must be positive')
+    .required('Amount is required')
+    .transform(({ originalValue }) => (originalValue === '' ? undefined : originalValue)),
   account: yup
     .string()
     .required('Account number is required')
     .matches(/^\d+$/, 'Account number must contain only digits'),
   address: yup.string().required('Address is required'),
-  description: yup.string().required(),
-  date: yup.date().required('Date is required'),
+  description: yup.string().required('Description is required'),
+  date: yup
+    .date()
+    .required('Date is required')
+    .transform(({ originalValue }) => (originalValue === '' ? undefined : originalValue)),
 });
 
 type FormInputs = Omit<Transaction, 'id'>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,7 @@ export interface Transaction {
   beneficiary: string;
   account: string;
   address: string;
-  date: string;
+  date: Date;
   description: string;
 }
 


### PR DESCRIPTION
Adjust the FormInputs type and validation rules in the schema according to your specific form requirements and Transaction type definition